### PR TITLE
feat: support animetsu.live as a second tracked site

### DIFF
--- a/src/content/adapters/animetsu.ts
+++ b/src/content/adapters/animetsu.ts
@@ -8,6 +8,15 @@ const HOST = "animetsu.live";
 const CARD_SELECTOR = 'a[href^="/anime/"]:has(.aspect-cover)';
 const TITLE_SELECTOR = ".line-clamp-2";
 
+// Path shape: /anime/{mongoId}, optionally followed by extra segments
+// (episode pages reuse the same prefix). Hex Mongo IDs are 24 chars, but we
+// accept any non-empty segment for forward compatibility.
+const WATCH_PATH_RE = /^\/anime\/([^/?#]+)/;
+
+// Watch-page header candidates, ordered most- to least- specific. Used as a
+// visible-DOM fallback when document.title hasn't been hydrated yet.
+const WATCH_TITLE_SELECTORS = ["div.flex-center.font-extrabold", "h1", "h2", "[class*='title']"];
+
 function extractCardAnime(card: Element): AnimeData | null {
     const href = card.getAttribute("href") || "";
     const idMatch = href.match(/^\/anime\/([^/?#]+)/);
@@ -17,6 +26,36 @@ function extractCardAnime(card: Element): AnimeData | null {
     const titleEl = card.querySelector(TITLE_SELECTOR);
     const animeTitle = titleEl?.textContent?.trim() || "";
     if (!animeTitle) return null;
+
+    return {
+        animeId,
+        animeTitle,
+        animeSlug: animeId,
+    };
+}
+
+function readWatchPageTitle(fallback: string): string {
+    const docTitle = document.title?.trim();
+    // Animetsu sets document.title to the anime title once the page hydrates.
+    // The literal "Animetsu" appears before hydration — treat that as not yet
+    // populated and fall back to a DOM scan.
+    if (docTitle && docTitle.toLowerCase() !== "animetsu") {
+        return docTitle;
+    }
+    for (const selector of WATCH_TITLE_SELECTORS) {
+        const el = document.querySelector(selector);
+        const text = el?.textContent?.trim();
+        if (text) return text;
+    }
+    return fallback;
+}
+
+function extractWatchPageAnime(): AnimeData | null {
+    const idMatch = window.location.pathname.match(WATCH_PATH_RE);
+    if (!idMatch) return null;
+
+    const animeId = idMatch[1];
+    const animeTitle = readWatchPageTitle(animeId);
 
     return {
         animeId,
@@ -51,7 +90,12 @@ export const animetsuAdapter: SiteAdapter = {
     cardSelector: CARD_SELECTOR,
     extractAnime: extractCardAnime,
     getInjectionTarget,
-    watchPage: null,
+    watchPage: {
+        // Match /anime/{id} and any nested path (e.g. /anime/{id}/episode/3)
+        // but NOT bare /anime or /browse.
+        matches: (url) => WATCH_PATH_RE.test(url.pathname),
+        extractAnime: extractWatchPageAnime,
+    },
     supportsClearHiddenButton: false,
     supportsDragAndDrop: false,
 };

--- a/src/content/adapters/animetsu.ts
+++ b/src/content/adapters/animetsu.ts
@@ -8,10 +8,12 @@ const HOST = "animetsu.live";
 const CARD_SELECTOR = 'a[href^="/anime/"]:has(.aspect-cover)';
 const TITLE_SELECTOR = ".line-clamp-2";
 
-// Path shape: /anime/{mongoId}, optionally followed by extra segments
-// (episode pages reuse the same prefix). Hex Mongo IDs are 24 chars, but we
-// accept any non-empty segment for forward compatibility.
-const WATCH_PATH_RE = /^\/anime\/([^/?#]+)/;
+// Animetsu has two single-anime URL shapes:
+//   /anime/{id}        → detail page with the episode list
+//   /watch/{id}?ep=N   → episode video player
+// Both expose the same anime id in the first segment.
+const WATCH_PATH_RE = /^\/(?:anime|watch)\/([^/?#]+)/;
+const EPISODE_PATH_RE = /^\/watch\//;
 
 // Watch-page header candidates, ordered most- to least- specific. Used as a
 // visible-DOM fallback when document.title hasn't been hydrated yet.
@@ -35,11 +37,18 @@ function extractCardAnime(card: Element): AnimeData | null {
 }
 
 function readWatchPageTitle(fallback: string): string {
-    const docTitle = document.title?.trim();
+    const docTitle = (document.title || "").trim();
+    const isEpisodePage = EPISODE_PATH_RE.test(window.location.pathname);
     // Animetsu sets document.title to the anime title once the page hydrates.
     // The literal "Animetsu" appears before hydration — treat that as not yet
     // populated and fall back to a DOM scan.
     if (docTitle && docTitle.toLowerCase() !== "animetsu") {
+        if (isEpisodePage && docTitle.includes(" - ")) {
+            // Episode pages format the title as "{episode} - {anime}". The anime
+            // portion sits at the tail; trim the episode prefix.
+            const trailing = docTitle.split(" - ").pop()?.trim();
+            if (trailing) return trailing;
+        }
         return docTitle;
     }
     for (const selector of WATCH_TITLE_SELECTORS) {
@@ -91,8 +100,8 @@ export const animetsuAdapter: SiteAdapter = {
     extractAnime: extractCardAnime,
     getInjectionTarget,
     watchPage: {
-        // Match /anime/{id} and any nested path (e.g. /anime/{id}/episode/3)
-        // but NOT bare /anime or /browse.
+        // Match /anime/{id} (detail page) and /watch/{id} (episode page) but
+        // not the bare /anime, /watch, or list paths like /browse.
         matches: (url) => WATCH_PATH_RE.test(url.pathname),
         extractAnime: extractWatchPageAnime,
     },

--- a/src/content/adapters/animetsu.ts
+++ b/src/content/adapters/animetsu.ts
@@ -92,7 +92,7 @@ function getInjectionTarget(card: Element): Element | null {
 
 export const animetsuAdapter: SiteAdapter = {
     id: "animetsu",
-    matches: (url) => url.host === HOST || url.host.endsWith(`.${HOST}`),
+    matches: (url) => url.hostname === HOST || url.hostname.endsWith(`.${HOST}`),
     // The flex-wrap grid that holds every card on /browse and other list
     // pages. The Tailwind `min-h-[30dvh]` arbitrary-value class is the most
     // distinctive hook on the page (only one element on /browse matches).

--- a/src/content/adapters/animetsu.ts
+++ b/src/content/adapters/animetsu.ts
@@ -93,18 +93,21 @@ function getInjectionTarget(card: Element): Element | null {
 export const animetsuAdapter: SiteAdapter = {
     id: "animetsu",
     matches: (url) => url.host === HOST || url.host.endsWith(`.${HOST}`),
-    // No dedicated list container — cards live inside the page's main grid.
-    // The empty selector keeps the container-based code paths inert.
-    containerSelector: "body",
+    // The flex-wrap grid that holds every card on /browse and other list
+    // pages. The Tailwind `min-h-[30dvh]` arbitrary-value class is the most
+    // distinctive hook on the page (only one element on /browse matches).
+    containerSelector: ".min-h-\\[30dvh\\]",
     cardSelector: CARD_SELECTOR,
     extractAnime: extractCardAnime,
     getInjectionTarget,
+    // Cards are wrapped in a Tailwind grid-slot div; reorder/hide must
+    // operate on that wrapper so the slot itself collapses or moves rather
+    // than leaving an empty padded gap.
+    getTileElement: (card) => (card.parentElement as Element | null) ?? card,
     watchPage: {
         // Match /anime/{id} (detail page) and /watch/{id} (episode page) but
         // not the bare /anime, /watch, or list paths like /browse.
         matches: (url) => WATCH_PATH_RE.test(url.pathname),
         extractAnime: extractWatchPageAnime,
     },
-    supportsClearHiddenButton: false,
-    supportsDragAndDrop: false,
 };

--- a/src/content/adapters/animetsu.ts
+++ b/src/content/adapters/animetsu.ts
@@ -1,0 +1,57 @@
+import type { AnimeData } from "@/commons/models";
+import type { SiteAdapter } from "./types";
+
+const HOST = "animetsu.live";
+
+// Anchors to anime cards on browse / list pages. The :has() filter excludes
+// non-card anchors (nav links, breadcrumbs, etc.) that may also point at /anime/.
+const CARD_SELECTOR = 'a[href^="/anime/"]:has(.aspect-cover)';
+const TITLE_SELECTOR = ".line-clamp-2";
+
+function extractCardAnime(card: Element): AnimeData | null {
+    const href = card.getAttribute("href") || "";
+    const idMatch = href.match(/^\/anime\/([^/?#]+)/);
+    if (!idMatch) return null;
+
+    const animeId = idMatch[1];
+    const titleEl = card.querySelector(TITLE_SELECTOR);
+    const animeTitle = titleEl?.textContent?.trim() || "";
+    if (!animeTitle) return null;
+
+    return {
+        animeId,
+        animeTitle,
+        animeSlug: animeId,
+    };
+}
+
+function getInjectionTarget(card: Element): Element | null {
+    // The poster wrapper is the card's first child. Its inner div carries
+    // Tailwind's `relative` class, which is the natural container for our
+    // absolute-positioned controls overlay.
+    const posterWrapper = card.firstElementChild as HTMLElement | null;
+    if (!posterWrapper) return null;
+
+    const innerRelative = posterWrapper.querySelector<HTMLElement>(":scope > .relative");
+    const target = innerRelative ?? posterWrapper;
+
+    if (target instanceof HTMLElement && target.style.position !== "relative") {
+        // Idempotent — keeps overlay positioning predictable across SPA re-renders.
+        target.style.position = "relative";
+    }
+    return target;
+}
+
+export const animetsuAdapter: SiteAdapter = {
+    id: "animetsu",
+    matches: (url) => url.host === HOST || url.host.endsWith(`.${HOST}`),
+    // No dedicated list container — cards live inside the page's main grid.
+    // The empty selector keeps the container-based code paths inert.
+    containerSelector: "body",
+    cardSelector: CARD_SELECTOR,
+    extractAnime: extractCardAnime,
+    getInjectionTarget,
+    watchPage: null,
+    supportsClearHiddenButton: false,
+    supportsDragAndDrop: false,
+};

--- a/src/content/adapters/hianime.ts
+++ b/src/content/adapters/hianime.ts
@@ -1,0 +1,94 @@
+import type { AnimeData } from "@/commons/models";
+import type { SiteAdapter } from "./types";
+
+const SELECTORS = {
+    CONTAINER: ".film_list-wrap",
+    ITEM: ".flw-item",
+    POSTER: ".film-poster",
+    TITLE_LINK: ".film-name a",
+} as const;
+
+const WATCH_PAGE_TITLE_SELECTORS = [
+    ".ani_detail-info h2",
+    ".watch-detail .title",
+    "h1.anime-title",
+    "h1",
+    "h2",
+    "[class*='title']",
+    ".film-name",
+    ".anime-title",
+];
+
+function extractCardAnime(card: Element): AnimeData | null {
+    const titleLink = card.querySelector(SELECTORS.TITLE_LINK) as HTMLAnchorElement | null;
+    if (!titleLink) return null;
+
+    const href = titleLink.getAttribute("href") || "";
+    const title = titleLink.getAttribute("title") || titleLink.textContent?.trim() || "";
+
+    const idMatch = href.match(/\/(?:watch\/)?([^/]+)$/);
+    if (!idMatch) return null;
+
+    const slug = idMatch[1];
+    const numericIdMatch = slug.match(/-(\d+)$/);
+    const animeId = numericIdMatch ? numericIdMatch[1] : slug;
+
+    return {
+        animeId,
+        animeTitle: title,
+        animeSlug: slug,
+    };
+}
+
+function extractWatchPageAnime(): AnimeData | null {
+    const url = window.location.href;
+    const urlMatch = url.match(/\/watch\/([^/?]+)/);
+    if (!urlMatch) return null;
+
+    const originalSlug = urlMatch[1];
+
+    let animeId = originalSlug;
+    const numericIdMatch = originalSlug.match(/-(\d+)$/);
+    if (numericIdMatch) {
+        animeId = numericIdMatch[1];
+    }
+
+    let animeTitle = originalSlug;
+    let titleSelectorUsed = "none";
+    for (const selector of WATCH_PAGE_TITLE_SELECTORS) {
+        const element = document.querySelector(selector);
+        if (element?.textContent?.trim()) {
+            animeTitle = element.textContent.trim();
+            titleSelectorUsed = selector;
+            break;
+        }
+    }
+
+    const animeData: AnimeData = {
+        animeId,
+        animeTitle,
+        animeSlug: originalSlug.toLowerCase(),
+    };
+
+    (animeData as AnimeData & { debugInfo?: unknown }).debugInfo = {
+        url,
+        originalSlug,
+        extractionStrategy: numericIdMatch ? "numeric-suffix" : "full-slug",
+        titleSelectorUsed,
+    };
+
+    return animeData;
+}
+
+export const hianimeAdapter: SiteAdapter = {
+    id: "hianime",
+    matches: () => true,
+    containerSelector: SELECTORS.CONTAINER,
+    cardSelector: SELECTORS.ITEM,
+    extractAnime: extractCardAnime,
+    getInjectionTarget: (card) => card.querySelector(SELECTORS.POSTER),
+    watchPage: {
+        matches: (url) => url.href.includes("/watch/"),
+        extractAnime: extractWatchPageAnime,
+    },
+};

--- a/src/content/adapters/index.ts
+++ b/src/content/adapters/index.ts
@@ -1,0 +1,11 @@
+import { hianimeAdapter } from "./hianime";
+import type { SiteAdapter } from "./types";
+
+export const adapters: SiteAdapter[] = [hianimeAdapter];
+
+export function selectAdapter(url: URL = new URL(window.location.href)): SiteAdapter | null {
+    return adapters.find((adapter) => adapter.matches(url)) ?? null;
+}
+
+export type { SiteAdapter, WatchPageAdapter } from "./types";
+export { hianimeAdapter };

--- a/src/content/adapters/index.ts
+++ b/src/content/adapters/index.ts
@@ -5,8 +5,16 @@ import type { SiteAdapter } from "./types";
 // Order matters: more-specific adapters first; hianime is the catch-all fallback.
 export const adapters: SiteAdapter[] = [animetsuAdapter, hianimeAdapter];
 
-export function selectAdapter(url: URL = new URL(window.location.href)): SiteAdapter | null {
-    return adapters.find((adapter) => adapter.matches(url)) ?? null;
+/**
+ * Resolve the SiteAdapter that should drive the content script for the given
+ * URL. The optional `candidates` parameter exists primarily for tests so they
+ * can pass a local list rather than mutating the exported singleton.
+ */
+export function selectAdapter(
+    url: URL = new URL(window.location.href),
+    candidates: readonly SiteAdapter[] = adapters,
+): SiteAdapter | null {
+    return candidates.find((adapter) => adapter.matches(url)) ?? null;
 }
 
 export type { SiteAdapter, WatchPageAdapter } from "./types";

--- a/src/content/adapters/index.ts
+++ b/src/content/adapters/index.ts
@@ -1,11 +1,13 @@
+import { animetsuAdapter } from "./animetsu";
 import { hianimeAdapter } from "./hianime";
 import type { SiteAdapter } from "./types";
 
-export const adapters: SiteAdapter[] = [hianimeAdapter];
+// Order matters: more-specific adapters first; hianime is the catch-all fallback.
+export const adapters: SiteAdapter[] = [animetsuAdapter, hianimeAdapter];
 
 export function selectAdapter(url: URL = new URL(window.location.href)): SiteAdapter | null {
     return adapters.find((adapter) => adapter.matches(url)) ?? null;
 }
 
 export type { SiteAdapter, WatchPageAdapter } from "./types";
-export { hianimeAdapter };
+export { animetsuAdapter, hianimeAdapter };

--- a/src/content/adapters/types.ts
+++ b/src/content/adapters/types.ts
@@ -13,4 +13,15 @@ export interface SiteAdapter {
     extractAnime(card: Element): AnimeData | null;
     getInjectionTarget(card: Element): Element | null;
     watchPage: WatchPageAdapter | null;
+    /**
+     * Whether the host has a dedicated anime-list container suitable for
+     * the "Clear Hidden" management button. Defaults to true.
+     */
+    supportsClearHiddenButton?: boolean;
+    /**
+     * Whether the host's tile layout supports tile drag-and-drop / folders.
+     * Currently both features are tightly coupled to the HiAnime DOM, so any
+     * additional adapter must opt in explicitly. Defaults to true.
+     */
+    supportsDragAndDrop?: boolean;
 }

--- a/src/content/adapters/types.ts
+++ b/src/content/adapters/types.ts
@@ -1,0 +1,16 @@
+import type { AnimeData } from "@/commons/models";
+
+export interface WatchPageAdapter {
+    matches(url: URL): boolean;
+    extractAnime(): AnimeData | null;
+}
+
+export interface SiteAdapter {
+    id: string;
+    matches(url: URL): boolean;
+    containerSelector: string;
+    cardSelector: string;
+    extractAnime(card: Element): AnimeData | null;
+    getInjectionTarget(card: Element): Element | null;
+    watchPage: WatchPageAdapter | null;
+}

--- a/src/content/adapters/types.ts
+++ b/src/content/adapters/types.ts
@@ -12,6 +12,13 @@ export interface SiteAdapter {
     cardSelector: string;
     extractAnime(card: Element): AnimeData | null;
     getInjectionTarget(card: Element): Element | null;
+    /**
+     * Element treated as the user-visible tile for hide/reorder operations.
+     * Some sites wrap each card in a grid-slot element (Animetsu) — those
+     * must return the wrapper so hiding it collapses the slot rather than
+     * leaving an empty padded gap. Defaults to the card itself.
+     */
+    getTileElement?(card: Element): Element;
     watchPage: WatchPageAdapter | null;
     /**
      * Whether the host has a dedicated anime-list container suitable for
@@ -20,8 +27,7 @@ export interface SiteAdapter {
     supportsClearHiddenButton?: boolean;
     /**
      * Whether the host's tile layout supports tile drag-and-drop / folders.
-     * Currently both features are tightly coupled to the HiAnime DOM, so any
-     * additional adapter must opt in explicitly. Defaults to true.
+     * Defaults to true.
      */
     supportsDragAndDrop?: boolean;
 }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -880,6 +880,7 @@ export async function addControlsToItem(element: Element): Promise<void> {
  * Add Clear Hidden button to the list container
  */
 export function addClearHiddenButton(): void {
+    if (activeAdapter?.supportsClearHiddenButton === false) return;
     const container = document.querySelector(SELECTORS.CONTAINER);
     if (!container) return;
 
@@ -3152,6 +3153,7 @@ export function createDragToolbar(): HTMLDivElement {
  * Insert drag toolbar into the page
  */
 export function insertDragToolbar(): void {
+    if (activeAdapter?.supportsDragAndDrop === false) return;
     // Only insert if container exists and toolbar doesn't exist
     const container = document.querySelector(SELECTORS.CONTAINER);
     if (!container) return;
@@ -3673,6 +3675,7 @@ export async function resetTileOrder(): Promise<void> {
  * Initialize drag-and-drop functionality
  */
 export async function initializeDragAndDrop(): Promise<void> {
+    if (activeAdapter?.supportsDragAndDrop === false) return;
     // Only initialize if container exists
     const container = document.querySelector(SELECTORS.CONTAINER);
     if (!container) return;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -53,6 +53,26 @@ const SELECTORS = {
     },
 };
 
+// Shared sentinel class applied to every tile we manage. Drag-and-drop, folder
+// logic, and tile-level CSS rules target this class so they remain
+// site-agnostic — the per-site card class (HiAnime's card class, the Animetsu
+// slot wrapper, …) is irrelevant once the tile has been tagged.
+const TILE_CLASS = "anime-list-tile";
+
+/**
+ * Resolve the user-visible tile for a given card and tag it with the shared
+ * sentinel class. Adapters may opt into a wrapper element (e.g. Animetsu's
+ * grid-slot div) so hide/reorder operations affect the slot rather than the
+ * inner card.
+ */
+function resolveTile(card: Element): HTMLElement {
+    const tile = (activeAdapter?.getTileElement?.(card) ?? card) as HTMLElement;
+    if (!tile.classList.contains(TILE_CLASS)) {
+        tile.classList.add(TILE_CLASS);
+    }
+    return tile;
+}
+
 // Cache for anime data extracted from DOM
 const animeDataCache = new Map<string, AnimeData>();
 
@@ -752,13 +772,15 @@ export async function handleHideClick(animeData: AnimeData, button: HTMLButtonEl
         const result = await animeService.hideAnime(animeData.animeId);
 
         if (result.success) {
-            // Find the parent anime item and hide it
-            const animeItem = button.closest(SELECTORS.ITEM);
-            if (animeItem) {
-                animeItem.classList.add("anime-hidden");
+            // Find the card, resolve its tile (the slot wrapper on adapters
+            // that opt into one) and hide that.
+            const card = button.closest(SELECTORS.ITEM);
+            if (card) {
+                const tile = resolveTile(card);
+                tile.classList.add("anime-hidden");
                 // Use CSS transition for smooth hiding
                 setTimeout(() => {
-                    (animeItem as HTMLElement).style.display = "none";
+                    tile.style.display = "none";
                 }, 300);
             }
             showToast(`Hidden "${animeData.animeTitle}"`, "success");
@@ -814,13 +836,18 @@ export async function addControlsToItem(element: Element): Promise<void> {
         const animeData = extractAnimeData(element);
         if (!animeData) return;
 
+        // Tag the user-visible tile so drag/drop and hide operate on the
+        // correct element (the slot wrapper on Animetsu, the card itself on
+        // HiAnime).
+        const tile = resolveTile(element);
+
         // Get unified anime status
         const status = await animeService.getAnimeStatus(animeData.animeId);
 
-        // Handle hidden anime - no controls shown, item is hidden
+        // Handle hidden anime - no controls shown, the entire tile is hidden
         if (status.isHidden) {
-            element.classList.add("anime-hidden");
-            (element as HTMLElement).style.display = "none";
+            tile.classList.add("anime-hidden");
+            tile.style.display = "none";
             return;
         }
 
@@ -948,7 +975,7 @@ export function setupObserver(): void {
                             addControlsToItem(element);
                             // Make draggable if drag mode is active
                             if (dragModeEnabled) {
-                                makeTileDraggable(element as HTMLElement);
+                                makeTileDraggable(resolveTile(element));
                             }
                         }
 
@@ -959,7 +986,7 @@ export function setupObserver(): void {
                                 addControlsToItem(item);
                                 // Make draggable if drag mode is active
                                 if (dragModeEnabled) {
-                                    makeTileDraggable(item as HTMLElement);
+                                    makeTileDraggable(resolveTile(item));
                                 }
                             });
                         }
@@ -974,14 +1001,14 @@ export function setupObserver(): void {
 
                         // Clean up if the removed node is an anime item
                         if (element.matches?.(itemSelector)) {
-                            removeTileDraggable(element as HTMLElement);
+                            removeTileDraggable(resolveTile(element));
                         }
 
                         // Clean up any anime items within the removed node
                         const items = element.querySelectorAll?.(itemSelector);
                         if (items) {
                             items.forEach((item) => {
-                                removeTileDraggable(item as HTMLElement);
+                                removeTileDraggable(resolveTile(item));
                             });
                         }
                     }
@@ -1494,37 +1521,37 @@ function injectStyles(): void {
         }
 
         /* Draggable tile styles */
-        .flw-item[draggable="true"] {
+        .anime-list-tile[draggable="true"] {
             cursor: grab;
             outline: 2px dashed rgba(139, 92, 246, 0.5);
             outline-offset: -2px;
             transition: outline 0.2s ease, outline-offset 0.2s ease, transform 0.2s ease, background 0.2s ease;
         }
 
-        .flw-item[draggable="true"]:active {
+        .anime-list-tile[draggable="true"]:active {
             cursor: grabbing;
         }
 
-        .flw-item.drag-over {
+        .anime-list-tile.drag-over {
             outline: 2px solid rgba(139, 92, 246, 0.8);
             outline-offset: -2px;
             transform: scale(1.02);
             background: rgba(139, 92, 246, 0.1);
         }
 
-        .flw-item.dragging {
+        .anime-list-tile.dragging {
             opacity: 0.5;
             transform: scale(0.98);
         }
 
         /* Keyboard selection state */
-        .flw-item.keyboard-selected {
+        .anime-list-tile.keyboard-selected {
             outline: 3px solid rgba(59, 130, 246, 0.8) !important;
             outline-offset: 2px !important;
             box-shadow: 0 0 12px rgba(59, 130, 246, 0.4);
         }
 
-        .flw-item[draggable="true"]:focus {
+        .anime-list-tile[draggable="true"]:focus {
             outline: 2px solid rgba(59, 130, 246, 0.6);
             outline-offset: 2px;
         }
@@ -1665,7 +1692,7 @@ function injectStyles(): void {
         }
 
         /* Ensure tiles inside folders display correctly */
-        .anime-folder-content .flw-item {
+        .anime-folder-content .anime-list-tile {
             width: 100% !important;
             display: block !important;
             min-width: 0;
@@ -2513,7 +2540,7 @@ function setupFolderDropZone(content: HTMLElement, folderId: string): void {
     content.addEventListener("dragover", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        if (draggedElement?.classList.contains("flw-item")) {
+        if (draggedElement?.classList.contains("anime-list-tile")) {
             if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
             content.closest(".anime-folder")?.classList.add("drag-over");
         }
@@ -2533,7 +2560,7 @@ function setupFolderDropZone(content: HTMLElement, folderId: string): void {
         e.stopPropagation();
         content.closest(".anime-folder")?.classList.remove("drag-over");
 
-        if (draggedElement?.classList.contains("flw-item")) {
+        if (draggedElement?.classList.contains("anime-list-tile")) {
             await handleDropIntoFolder(draggedElement, folderId);
         }
     });
@@ -2858,13 +2885,13 @@ export function removeFolderDraggable(folderEl: HTMLElement): void {
  */
 function handleContainerDragOver(e: DragEvent): void {
     // Only handle if dragging a tile from a folder
-    if (!draggedElement?.classList.contains("flw-item")) return;
+    if (!draggedElement?.classList.contains("anime-list-tile")) return;
     const fromFolder = draggedElement.closest(".anime-folder-content");
     if (!fromFolder) return;
 
     // Check if dropping directly on container (not on a tile or folder)
     const target = e.target as HTMLElement;
-    if (target.closest(".flw-item") || target.closest(".anime-folder")) return;
+    if (target.closest(".anime-list-tile") || target.closest(".anime-folder")) return;
 
     e.preventDefault();
     if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
@@ -2875,14 +2902,14 @@ function handleContainerDragOver(e: DragEvent): void {
  */
 async function handleContainerDrop(e: DragEvent): Promise<void> {
     // Only handle if dragging a tile from a folder
-    if (!draggedElement?.classList.contains("flw-item")) return;
+    if (!draggedElement?.classList.contains("anime-list-tile")) return;
     const fromFolder = draggedElement.closest(".anime-folder-content");
     const sourceFolderId = fromFolder?.closest(".anime-folder")?.getAttribute("data-folder-id");
     if (!fromFolder || !sourceFolderId) return;
 
     // Check if dropping directly on container (not on a tile or folder)
     const target = e.target as HTMLElement;
-    if (target.closest(".flw-item") || target.closest(".anime-folder")) return;
+    if (target.closest(".anime-list-tile") || target.closest(".anime-folder")) return;
 
     e.preventDefault();
     e.stopPropagation();
@@ -3314,10 +3341,12 @@ export function enableDragMode(): void {
     const container = document.querySelector(SELECTORS.CONTAINER) as HTMLElement;
     if (!container) return;
 
-    // Make tiles draggable
-    const items = container.querySelectorAll(SELECTORS.ITEM);
-    items.forEach((item) => {
-        makeTileDraggable(item as HTMLElement);
+    // Make tiles draggable. Resolve each card to its tile element so that on
+    // adapters with a slot wrapper (Animetsu), the wrapper — not the inner
+    // card — receives the draggable attribute and event listeners.
+    const cards = container.querySelectorAll(SELECTORS.ITEM);
+    cards.forEach((card) => {
+        makeTileDraggable(resolveTile(card));
     });
 
     // Make folders draggable
@@ -3361,9 +3390,9 @@ export function disableDragMode(): void {
     if (!container) return;
 
     // Remove draggable from tiles
-    const items = container.querySelectorAll(SELECTORS.ITEM);
-    items.forEach((item) => {
-        removeTileDraggable(item as HTMLElement);
+    const cards = container.querySelectorAll(SELECTORS.ITEM);
+    cards.forEach((card) => {
+        removeTileDraggable(resolveTile(card));
     });
 
     // Remove draggable from folders
@@ -3461,9 +3490,9 @@ async function handleDrop(e: DragEvent): Promise<void> {
 
     if (!draggedElement || draggedElement === target) return;
 
-    const isDraggedTile = draggedElement.classList.contains("flw-item");
+    const isDraggedTile = draggedElement.classList.contains("anime-list-tile");
     const isDraggedFolder = draggedElement.classList.contains("anime-folder");
-    const isTargetTile = target.classList.contains("flw-item");
+    const isTargetTile = target.classList.contains("anime-list-tile");
     const isTargetFolder = target.classList.contains("anime-folder");
 
     // Check if dragged element is coming from inside a folder
@@ -3574,7 +3603,7 @@ function debouncedSaveRootOrder(): void {
                 if (child.classList.contains("anime-folder")) {
                     const folderId = child.getAttribute("data-folder-id");
                     if (folderId) rootItems.push(`folder:${folderId}`);
-                } else if (child.classList.contains("flw-item")) {
+                } else if (child.classList.contains("anime-list-tile")) {
                     const animeData = extractAnimeData(child);
                     if (animeData) rootItems.push(animeData.animeId);
                 }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -2,6 +2,7 @@ import type { AnimeData, AnimeStatus, TileOrder, Folder, FolderOrder } from "@/c
 import { StorageKeys } from "@/commons/models";
 import { AnimeService } from "@/commons/services";
 import { StorageAdapter } from "@/commons/adapters/StorageAdapter";
+import { selectAdapter, type SiteAdapter } from "@/content/adapters";
 
 /**
  * Content script for anime website integration
@@ -33,13 +34,24 @@ console.log("AnimeList content script loaded");
 // Initialize the anime service
 const animeService = new AnimeService();
 
-// Constants for DOM selectors based on the requirements
+// Resolve the active site adapter. When no adapter matches, the script self-disables.
+let activeAdapter: SiteAdapter | null = null;
+try {
+    activeAdapter = selectAdapter();
+} catch {
+    activeAdapter = null;
+}
+
+// Selector aliases routed through the active adapter. When no adapter matches,
+// the empty-string fallbacks keep guarded querySelector calls inert.
 const SELECTORS = {
-    CONTAINER: ".film_list-wrap",
-    ITEM: ".flw-item",
-    POSTER: ".film-poster",
-    TITLE_LINK: ".film-name a",
-} as const;
+    get CONTAINER(): string {
+        return activeAdapter?.containerSelector ?? "";
+    },
+    get ITEM(): string {
+        return activeAdapter?.cardSelector ?? "";
+    },
+};
 
 // Cache for anime data extracted from DOM
 const animeDataCache = new Map<string, AnimeData>();
@@ -177,34 +189,16 @@ function repositionToasts(): void {
 }
 
 /**
- * Extract anime data from a DOM element
+ * Extract anime data from a DOM element via the active site adapter.
  */
 export function extractAnimeData(element: Element): AnimeData | null {
     try {
-        const titleLink = element.querySelector(SELECTORS.TITLE_LINK) as HTMLAnchorElement;
-        if (!titleLink) return null;
+        if (!activeAdapter) return null;
 
-        const href = titleLink.getAttribute("href") || "";
-        const title = titleLink.getAttribute("title") || titleLink.textContent?.trim() || "";
+        const animeData = activeAdapter.extractAnime(element);
+        if (!animeData) return null;
 
-        // Extract anime ID from href (e.g., "/watch/anime-name-12345" -> "12345")
-        const idMatch = href.match(/\/(?:watch\/)?([^/]+)$/);
-        if (!idMatch) return null;
-
-        const slug = idMatch[1];
-        // Extract numeric ID from slug if present, otherwise use the full slug
-        const numericIdMatch = slug.match(/-(\d+)$/);
-        const animeId = numericIdMatch ? numericIdMatch[1] : slug;
-
-        const animeData: AnimeData = {
-            animeId,
-            animeTitle: title,
-            animeSlug: slug,
-        };
-
-        // Cache the data
-        animeDataCache.set(animeId, animeData);
-
+        animeDataCache.set(animeData.animeId, animeData);
         return animeData;
     } catch (error) {
         console.error("Error extracting anime data:", error);
@@ -872,10 +866,10 @@ export async function addControlsToItem(element: Element): Promise<void> {
             controlsContainer.classList.add("clean-state");
         }
 
-        // Find the poster element and add controls
-        const poster = element.querySelector(SELECTORS.POSTER);
-        if (poster) {
-            poster.appendChild(controlsContainer);
+        // Find the injection target via the active adapter and add controls
+        const injectionTarget = activeAdapter?.getInjectionTarget(element) ?? null;
+        if (injectionTarget) {
+            injectionTarget.appendChild(controlsContainer);
         }
     } catch (error) {
         console.error("Error adding controls to item:", error);
@@ -939,6 +933,8 @@ export async function initializeControls(): Promise<void> {
  */
 export function setupObserver(): void {
     const observer = new MutationObserver((mutations) => {
+        const itemSelector = SELECTORS.ITEM;
+        if (!itemSelector) return;
         for (const mutation of mutations) {
             if (mutation.type === "childList") {
                 // Handle added nodes
@@ -947,7 +943,7 @@ export function setupObserver(): void {
                         const element = node as Element;
 
                         // Check if the added node is an anime item
-                        if (element.matches(SELECTORS.ITEM)) {
+                        if (element.matches(itemSelector)) {
                             addControlsToItem(element);
                             // Make draggable if drag mode is active
                             if (dragModeEnabled) {
@@ -956,7 +952,7 @@ export function setupObserver(): void {
                         }
 
                         // Check if the added node contains anime items
-                        const items = element.querySelectorAll?.(SELECTORS.ITEM);
+                        const items = element.querySelectorAll?.(itemSelector);
                         if (items) {
                             items.forEach((item) => {
                                 addControlsToItem(item);
@@ -976,12 +972,12 @@ export function setupObserver(): void {
                         const element = node as Element;
 
                         // Clean up if the removed node is an anime item
-                        if (element.matches?.(SELECTORS.ITEM)) {
+                        if (element.matches?.(itemSelector)) {
                             removeTileDraggable(element as HTMLElement);
                         }
 
                         // Clean up any anime items within the removed node
-                        const items = element.querySelectorAll?.(SELECTORS.ITEM);
+                        const items = element.querySelectorAll?.(itemSelector);
                         if (items) {
                             items.forEach((item) => {
                                 removeTileDraggable(item as HTMLElement);
@@ -1768,6 +1764,11 @@ function injectStyles(): void {
  */
 export async function init(): Promise<void> {
     try {
+        // No adapter matched the current host — content script self-disables.
+        if (!activeAdapter) {
+            return;
+        }
+
         // Wait for DOM to be ready
         if (document.readyState === "loading") {
             document.addEventListener("DOMContentLoaded", init);
@@ -1822,71 +1823,27 @@ function getSinglePageAnimeService(): AnimeService {
 }
 
 /**
- * Check if current page is a watch page
+ * Check if current page is a watch / single-anime page (delegated to adapter).
  */
 export function isWatchPage(): boolean {
-    return window.location.href.includes("/watch/");
+    if (!activeAdapter?.watchPage) return false;
+    try {
+        return activeAdapter.watchPage.matches(new URL(window.location.href));
+    } catch {
+        return false;
+    }
 }
 
 /**
- * Extract anime data from watch page
+ * Extract anime data from a watch / single-anime page (delegated to adapter).
  */
 export function extractSinglePageAnimeData(): AnimeData | null {
     try {
-        const url = window.location.href;
-        const urlMatch = url.match(/\/watch\/([^/?]+)/);
-        if (!urlMatch) return null;
-
-        const originalSlug = urlMatch[1];
-
-        // Try multiple ID extraction strategies
-        let animeId = originalSlug;
-
-        // Strategy 1: Extract numeric ID from end (e.g., "anime-name-12345" -> "12345")
-        const numericIdMatch = originalSlug.match(/-(\d+)$/);
-        if (numericIdMatch) {
-            animeId = numericIdMatch[1];
+        if (!activeAdapter?.watchPage) return null;
+        const animeData = activeAdapter.watchPage.extractAnime();
+        if (animeData) {
+            console.log("Extracted anime data from watch page:", animeData);
         }
-
-        // Strategy 2: If no numeric suffix, use the full slug
-        // This handles cases where the anime ID is the full slug
-
-        // Try different selectors to get anime title
-        const titleSelectors = [
-            ".ani_detail-info h2",
-            ".watch-detail .title",
-            "h1.anime-title",
-            "h1",
-            "h2",
-            "[class*='title']",
-            ".film-name",
-            ".anime-title",
-        ];
-
-        let animeTitle = originalSlug; // Fallback to original slug
-        for (const selector of titleSelectors) {
-            const element = document.querySelector(selector);
-            if (element?.textContent?.trim()) {
-                animeTitle = element.textContent.trim();
-                break;
-            }
-        }
-
-        const animeData = {
-            animeId,
-            animeTitle,
-            animeSlug: originalSlug.toLowerCase(),
-        };
-
-        // Store debug info for modal display
-        (animeData as any).debugInfo = {
-            url,
-            originalSlug,
-            extractionStrategy: numericIdMatch ? "numeric-suffix" : "full-slug",
-            titleSelectorUsed: titleSelectors.find((sel) => document.querySelector(sel)?.textContent?.trim()) || "none",
-        };
-
-        console.log("Extracted anime data from watch page:", animeData);
         return animeData;
     } catch (error) {
         console.error("Error extracting anime data:", error);
@@ -3727,8 +3684,13 @@ export async function initializeDragAndDrop(): Promise<void> {
     await restoreFolderOrder();
 }
 
-// Only auto-initialize if not in test environment
-if (typeof window !== "undefined" && typeof document !== "undefined" && (globalThis as any).window?.location) {
+// Only auto-initialize if not in test environment AND a site adapter matched.
+if (
+    typeof window !== "undefined" &&
+    typeof document !== "undefined" &&
+    (globalThis as any).window?.location &&
+    activeAdapter
+) {
     init();
 
     // Initialize single page functionality

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -59,22 +59,31 @@ const SELECTORS = {
 // slot wrapper, …) is irrelevant once the tile has been tagged.
 const TILE_CLASS = "anime-list-tile";
 
+// Cache for anime data extracted from DOM
+const animeDataCache = new Map<string, AnimeData>();
+
 /**
  * Resolve the user-visible tile for a given card and tag it with the shared
  * sentinel class. Adapters may opt into a wrapper element (e.g. Animetsu's
  * grid-slot div) so hide/reorder operations affect the slot rather than the
- * inner card.
+ * inner card. The card's anime id is also persisted on the tile via
+ * `data-anime-id` so reorder / folder code paths can treat the tile as the
+ * canonical handle even when tile !== card.
  */
 function resolveTile(card: Element): HTMLElement {
     const tile = (activeAdapter?.getTileElement?.(card) ?? card) as HTMLElement;
     if (!tile.classList.contains(TILE_CLASS)) {
         tile.classList.add(TILE_CLASS);
     }
+    if (!tile.dataset.animeId) {
+        const animeData = activeAdapter?.extractAnime(card) ?? null;
+        if (animeData) {
+            animeDataCache.set(animeData.animeId, animeData);
+            tile.dataset.animeId = animeData.animeId;
+        }
+    }
     return tile;
 }
-
-// Cache for anime data extracted from DOM
-const animeDataCache = new Map<string, AnimeData>();
 
 // Toast notification system
 interface Toast {
@@ -210,12 +219,36 @@ function repositionToasts(): void {
 
 /**
  * Extract anime data from a DOM element via the active site adapter.
+ *
+ * Accepts either a card or a tile wrapper. Resolution order:
+ *   1. `element.dataset.animeId` if it points at a cached entry (fast path
+ *      written by `resolveTile`)
+ *   2. The element itself, if it matches the adapter's card selector
+ *   3. The first descendant matching the card selector
+ *
+ * Folder / drag-and-drop code can therefore safely call this with the
+ * `.anime-list-tile` wrapper even when the wrapper isn't itself a card.
  */
 export function extractAnimeData(element: Element): AnimeData | null {
     try {
         if (!activeAdapter) return null;
 
-        const animeData = activeAdapter.extractAnime(element);
+        const datasetId = (element as HTMLElement).dataset?.animeId;
+        if (datasetId) {
+            const cached = animeDataCache.get(datasetId);
+            if (cached) return cached;
+        }
+
+        const cardSelector = activeAdapter.cardSelector;
+        const matchesSelf =
+            cardSelector && typeof element.matches === "function" ? element.matches(cardSelector) : false;
+        const card = matchesSelf
+            ? element
+            : (cardSelector && typeof element.querySelector === "function"
+                  ? element.querySelector(cardSelector)
+                  : null) || element;
+
+        const animeData = activeAdapter.extractAnime(card);
         if (!animeData) return null;
 
         animeDataCache.set(animeData.animeId, animeData);

--- a/test/content/adapters/animetsu.test.ts
+++ b/test/content/adapters/animetsu.test.ts
@@ -26,11 +26,29 @@ function buildCard({
 }
 
 describe("animetsu adapter", () => {
-    it("declares its identity and feature flags", () => {
+    it("declares its identity and exposes the watch-page handler", () => {
         expect(animetsuAdapter.id).toBe("animetsu");
-        expect(animetsuAdapter.supportsClearHiddenButton).toBe(false);
-        expect(animetsuAdapter.supportsDragAndDrop).toBe(false);
         expect(animetsuAdapter.watchPage).not.toBeNull();
+    });
+
+    it("anchors the clear-hidden / drag-and-drop features on the grid container", () => {
+        // No opt-out flags set → the script-wide defaults (enabled) apply, so
+        // both features run on Animetsu against the grid container selector.
+        expect(animetsuAdapter.supportsClearHiddenButton).toBeUndefined();
+        expect(animetsuAdapter.supportsDragAndDrop).toBeUndefined();
+        expect(animetsuAdapter.containerSelector).toBe(".min-h-\\[30dvh\\]");
+    });
+
+    it("returns the parent slot wrapper as the tile element", () => {
+        const slot = document.createElement("div");
+        const card = document.createElement("a");
+        slot.appendChild(card);
+        expect(animetsuAdapter.getTileElement?.(card)).toBe(slot);
+    });
+
+    it("falls back to the card itself when no parent exists", () => {
+        const card = document.createElement("a");
+        expect(animetsuAdapter.getTileElement?.(card)).toBe(card);
     });
 
     it("matches animetsu.live and its subdomains only", () => {

--- a/test/content/adapters/animetsu.test.ts
+++ b/test/content/adapters/animetsu.test.ts
@@ -58,6 +58,10 @@ describe("animetsu adapter", () => {
         expect(animetsuAdapter.matches(new URL("https://example.com/animetsu.live"))).toBe(false);
     });
 
+    it("matches when an explicit port is present in the URL", () => {
+        expect(animetsuAdapter.matches(new URL("https://animetsu.live:8443/browse"))).toBe(true);
+    });
+
     it("scopes its card selector to anchors with a poster wrapper", () => {
         expect(animetsuAdapter.cardSelector).toBe('a[href^="/anime/"]:has(.aspect-cover)');
     });

--- a/test/content/adapters/animetsu.test.ts
+++ b/test/content/adapters/animetsu.test.ts
@@ -112,15 +112,18 @@ describe("animetsu adapter — watch page", () => {
         vi.restoreAllMocks();
     });
 
-    it("matches /anime/{id} URLs", () => {
+    it("matches both /anime/{id} detail pages and /watch/{id} episode pages", () => {
         expect(watchPage.matches(new URL("https://animetsu.live/anime/abc123"))).toBe(true);
         expect(watchPage.matches(new URL("https://animetsu.live/anime/abc123/episode/4"))).toBe(true);
+        expect(watchPage.matches(new URL("https://animetsu.live/watch/abc123?ep=1"))).toBe(true);
+        expect(watchPage.matches(new URL("https://animetsu.live/watch/abc123"))).toBe(true);
     });
 
-    it("does not match list, root, or bare /anime URLs", () => {
+    it("does not match list, root, or bare prefix URLs", () => {
         expect(watchPage.matches(new URL("https://animetsu.live/browse"))).toBe(false);
         expect(watchPage.matches(new URL("https://animetsu.live/"))).toBe(false);
         expect(watchPage.matches(new URL("https://animetsu.live/anime"))).toBe(false);
+        expect(watchPage.matches(new URL("https://animetsu.live/watch"))).toBe(false);
     });
 
     it("extracts id from path and title from document.title once hydrated", () => {
@@ -160,5 +163,35 @@ describe("animetsu adapter — watch page", () => {
             pathname: "/browse",
         } as Location);
         expect(watchPage.extractAnime()).toBeNull();
+    });
+
+    it("strips the episode prefix from /watch/ document titles", () => {
+        vi.spyOn(window, "location", "get").mockReturnValue({
+            pathname: "/watch/abc123",
+            search: "?ep=1",
+        } as Location);
+        document.title = "To You Two Thousand Years Later - Attack on Titan";
+        expect(watchPage.extractAnime()?.animeTitle).toBe("Attack on Titan");
+    });
+
+    it("uses /anime/ document titles verbatim (no dash splitting)", () => {
+        vi.spyOn(window, "location", "get").mockReturnValue({
+            pathname: "/anime/abc123",
+        } as Location);
+        document.title = "Steins;Gate - The Movie";
+        expect(watchPage.extractAnime()?.animeTitle).toBe("Steins;Gate - The Movie");
+    });
+
+    it("extracts the id from /watch/ paths", () => {
+        vi.spyOn(window, "location", "get").mockReturnValue({
+            pathname: "/watch/abc123",
+            search: "?ep=4",
+        } as Location);
+        document.title = "Some Episode - Some Anime";
+        expect(watchPage.extractAnime()).toEqual({
+            animeId: "abc123",
+            animeTitle: "Some Anime",
+            animeSlug: "abc123",
+        });
     });
 });

--- a/test/content/adapters/animetsu.test.ts
+++ b/test/content/adapters/animetsu.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { animetsuAdapter } from "@/content/adapters/animetsu";
 
 function buildCard({
@@ -30,7 +30,7 @@ describe("animetsu adapter", () => {
         expect(animetsuAdapter.id).toBe("animetsu");
         expect(animetsuAdapter.supportsClearHiddenButton).toBe(false);
         expect(animetsuAdapter.supportsDragAndDrop).toBe(false);
-        expect(animetsuAdapter.watchPage).toBeNull();
+        expect(animetsuAdapter.watchPage).not.toBeNull();
     });
 
     it("matches animetsu.live and its subdomains only", () => {
@@ -95,5 +95,70 @@ describe("animetsu adapter", () => {
         const target = animetsuAdapter.getInjectionTarget(card) as HTMLElement;
         expect(target).toBe(wrapper);
         expect(target.style.position).toBe("relative");
+    });
+});
+
+describe("animetsu adapter — watch page", () => {
+    const watchPage = animetsuAdapter.watchPage!;
+    const originalTitle = document.title;
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        document.title = "Animetsu";
+    });
+
+    afterEach(() => {
+        document.title = originalTitle;
+        vi.restoreAllMocks();
+    });
+
+    it("matches /anime/{id} URLs", () => {
+        expect(watchPage.matches(new URL("https://animetsu.live/anime/abc123"))).toBe(true);
+        expect(watchPage.matches(new URL("https://animetsu.live/anime/abc123/episode/4"))).toBe(true);
+    });
+
+    it("does not match list, root, or bare /anime URLs", () => {
+        expect(watchPage.matches(new URL("https://animetsu.live/browse"))).toBe(false);
+        expect(watchPage.matches(new URL("https://animetsu.live/"))).toBe(false);
+        expect(watchPage.matches(new URL("https://animetsu.live/anime"))).toBe(false);
+    });
+
+    it("extracts id from path and title from document.title once hydrated", () => {
+        vi.spyOn(window, "location", "get").mockReturnValue({
+            pathname: "/anime/abc123",
+        } as Location);
+        document.title = "Attack on Titan";
+        expect(watchPage.extractAnime()).toEqual({
+            animeId: "abc123",
+            animeTitle: "Attack on Titan",
+            animeSlug: "abc123",
+        });
+    });
+
+    it("falls back to a DOM heading when document.title is still 'Animetsu'", () => {
+        vi.spyOn(window, "location", "get").mockReturnValue({
+            pathname: "/anime/abc123",
+        } as Location);
+        document.title = "Animetsu";
+        const heading = document.createElement("div");
+        heading.className = "flex-center font-extrabold";
+        heading.textContent = "Demon Slayer";
+        document.body.appendChild(heading);
+        expect(watchPage.extractAnime()?.animeTitle).toBe("Demon Slayer");
+    });
+
+    it("falls back to the anime id when no title source is available", () => {
+        vi.spyOn(window, "location", "get").mockReturnValue({
+            pathname: "/anime/zzzz",
+        } as Location);
+        document.title = "Animetsu";
+        expect(watchPage.extractAnime()?.animeTitle).toBe("zzzz");
+    });
+
+    it("returns null when path does not match the watch shape", () => {
+        vi.spyOn(window, "location", "get").mockReturnValue({
+            pathname: "/browse",
+        } as Location);
+        expect(watchPage.extractAnime()).toBeNull();
     });
 });

--- a/test/content/adapters/animetsu.test.ts
+++ b/test/content/adapters/animetsu.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { animetsuAdapter } from "@/content/adapters/animetsu";
+
+function buildCard({
+    href = "/anime/6989b89f29cf95f4eb03b4ee",
+    title = "Attack on Titan",
+}: { href?: string; title?: string } = {}): HTMLAnchorElement {
+    const card = document.createElement("a");
+    card.setAttribute("href", href);
+    card.className = "flex flex-col w-full gap-2 cursor-pointer";
+    card.innerHTML = `
+        <div class="flex aspect-cover w-full bg-white/10 radius-xl">
+            <div class="relative size-full flex items-center justify-center select-none shrink-0">
+                <img />
+            </div>
+        </div>
+        <div class="flex w-full flex-col gap-1">
+            <div class="w-full flex-center justify-between text-2xs sm:text-xs text-muted">
+                <span>TV Show</span>
+                <span>2013</span>
+            </div>
+            <div class="line-clamp-2 font-medium xl:font-semibold text-xs sm:text-sm">${title}</div>
+        </div>
+    `;
+    return card;
+}
+
+describe("animetsu adapter", () => {
+    it("declares its identity and feature flags", () => {
+        expect(animetsuAdapter.id).toBe("animetsu");
+        expect(animetsuAdapter.supportsClearHiddenButton).toBe(false);
+        expect(animetsuAdapter.supportsDragAndDrop).toBe(false);
+        expect(animetsuAdapter.watchPage).toBeNull();
+    });
+
+    it("matches animetsu.live and its subdomains only", () => {
+        expect(animetsuAdapter.matches(new URL("https://animetsu.live/browse"))).toBe(true);
+        expect(animetsuAdapter.matches(new URL("https://www.animetsu.live/anime/abc"))).toBe(true);
+        expect(animetsuAdapter.matches(new URL("https://hianime.to/home"))).toBe(false);
+        expect(animetsuAdapter.matches(new URL("https://example.com/animetsu.live"))).toBe(false);
+    });
+
+    it("scopes its card selector to anchors with a poster wrapper", () => {
+        expect(animetsuAdapter.cardSelector).toBe('a[href^="/anime/"]:has(.aspect-cover)');
+    });
+
+    it("extracts the anime id from the /anime/{id} path", () => {
+        const card = buildCard({ href: "/anime/6989b89f29cf95f4eb03b4ee", title: "Attack on Titan" });
+        expect(animetsuAdapter.extractAnime(card)).toEqual({
+            animeId: "6989b89f29cf95f4eb03b4ee",
+            animeTitle: "Attack on Titan",
+            animeSlug: "6989b89f29cf95f4eb03b4ee",
+        });
+    });
+
+    it("strips trailing query strings and fragments from the href", () => {
+        const card = buildCard({ href: "/anime/abc123?ref=home", title: "Sample" });
+        expect(animetsuAdapter.extractAnime(card)?.animeId).toBe("abc123");
+    });
+
+    it("returns null when the title is missing", () => {
+        const card = buildCard({ title: "" });
+        expect(animetsuAdapter.extractAnime(card)).toBeNull();
+    });
+
+    it("returns null when the href is malformed", () => {
+        const card = document.createElement("a");
+        card.setAttribute("href", "/browse");
+        expect(animetsuAdapter.extractAnime(card)).toBeNull();
+    });
+
+    it("returns the inner relative wrapper as the injection target", () => {
+        const card = buildCard();
+        const target = animetsuAdapter.getInjectionTarget(card) as HTMLElement | null;
+        expect(target).not.toBeNull();
+        expect(target?.classList.contains("relative")).toBe(true);
+    });
+
+    it("forces position:relative on the injection target idempotently", () => {
+        const card = buildCard();
+        const first = animetsuAdapter.getInjectionTarget(card) as HTMLElement;
+        expect(first.style.position).toBe("relative");
+        // Second call should not mutate twice nor pick a different element.
+        const second = animetsuAdapter.getInjectionTarget(card) as HTMLElement;
+        expect(second).toBe(first);
+        expect(second.style.position).toBe("relative");
+    });
+
+    it("falls back to the poster wrapper when the relative inner div is missing", () => {
+        const card = document.createElement("a");
+        card.setAttribute("href", "/anime/abc");
+        const wrapper = document.createElement("div");
+        wrapper.className = "aspect-cover";
+        card.appendChild(wrapper);
+        const target = animetsuAdapter.getInjectionTarget(card) as HTMLElement;
+        expect(target).toBe(wrapper);
+        expect(target.style.position).toBe("relative");
+    });
+});

--- a/test/content/adapters/registry.test.ts
+++ b/test/content/adapters/registry.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { adapters, hianimeAdapter, selectAdapter } from "@/content/adapters";
+
+describe("content/adapters registry", () => {
+    it("includes the hianime adapter", () => {
+        expect(adapters).toContain(hianimeAdapter);
+    });
+
+    it("selects the hianime adapter by default", () => {
+        const adapter = selectAdapter(new URL("https://example.com/anything"));
+        expect(adapter).toBe(hianimeAdapter);
+    });
+
+    it("returns null when no adapter matches", () => {
+        const fakeAdapter = { ...hianimeAdapter, matches: () => false };
+        const original = adapters.slice();
+        adapters.length = 0;
+        adapters.push(fakeAdapter);
+        try {
+            const adapter = selectAdapter(new URL("https://example.com/anything"));
+            expect(adapter).toBeNull();
+        } finally {
+            adapters.length = 0;
+            adapters.push(...original);
+        }
+    });
+});
+
+describe("hianime adapter", () => {
+    it("exposes the legacy CSS selectors", () => {
+        expect(hianimeAdapter.containerSelector).toBe(".film_list-wrap");
+        expect(hianimeAdapter.cardSelector).toBe(".flw-item");
+    });
+
+    it("extracts numeric anime id from the standard href shape", () => {
+        const card = document.createElement("div");
+        card.innerHTML = `
+            <div class="film-name">
+                <a href="/watch/some-anime-12345" title="Some Anime">Some Anime</a>
+            </div>
+        `;
+        const data = hianimeAdapter.extractAnime(card);
+        expect(data).toEqual({
+            animeId: "12345",
+            animeTitle: "Some Anime",
+            animeSlug: "some-anime-12345",
+        });
+    });
+
+    it("falls back to slug when no numeric suffix is present", () => {
+        const card = document.createElement("div");
+        card.innerHTML = `
+            <div class="film-name">
+                <a href="/watch/cool-anime-slug" title="Cool Anime">Cool Anime</a>
+            </div>
+        `;
+        const data = hianimeAdapter.extractAnime(card);
+        expect(data?.animeId).toBe("cool-anime-slug");
+        expect(data?.animeSlug).toBe("cool-anime-slug");
+    });
+
+    it("returns null when title link is missing", () => {
+        const card = document.createElement("div");
+        expect(hianimeAdapter.extractAnime(card)).toBeNull();
+    });
+
+    it("returns the .film-poster element as injection target", () => {
+        const card = document.createElement("div");
+        card.innerHTML = `<div class="film-poster"></div>`;
+        const target = hianimeAdapter.getInjectionTarget(card);
+        expect(target).not.toBeNull();
+        expect(target?.classList.contains("film-poster")).toBe(true);
+    });
+
+    it("matches /watch/ urls as watch pages", () => {
+        expect(hianimeAdapter.watchPage?.matches(new URL("https://hianime.to/watch/foo-12"))).toBe(true);
+        expect(hianimeAdapter.watchPage?.matches(new URL("https://hianime.to/home"))).toBe(false);
+    });
+});

--- a/test/content/adapters/registry.test.ts
+++ b/test/content/adapters/registry.test.ts
@@ -1,12 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { adapters, hianimeAdapter, selectAdapter } from "@/content/adapters";
+import { adapters, animetsuAdapter, hianimeAdapter, selectAdapter } from "@/content/adapters";
 
 describe("content/adapters registry", () => {
-    it("includes the hianime adapter", () => {
+    it("includes both built-in adapters", () => {
+        expect(adapters).toContain(animetsuAdapter);
         expect(adapters).toContain(hianimeAdapter);
     });
 
-    it("selects the hianime adapter by default", () => {
+    it("registers more-specific adapters before the hianime catch-all", () => {
+        expect(adapters.indexOf(animetsuAdapter)).toBeLessThan(adapters.indexOf(hianimeAdapter));
+    });
+
+    it("selects the animetsu adapter for animetsu.live URLs", () => {
+        const adapter = selectAdapter(new URL("https://animetsu.live/browse"));
+        expect(adapter).toBe(animetsuAdapter);
+    });
+
+    it("falls back to the hianime adapter for unknown hosts", () => {
         const adapter = selectAdapter(new URL("https://example.com/anything"));
         expect(adapter).toBe(hianimeAdapter);
     });

--- a/test/content/adapters/registry.test.ts
+++ b/test/content/adapters/registry.test.ts
@@ -22,17 +22,11 @@ describe("content/adapters registry", () => {
     });
 
     it("returns null when no adapter matches", () => {
+        // Pass a local list rather than mutating the exported singleton so the
+        // test stays safe under Vitest's parallel runner.
         const fakeAdapter = { ...hianimeAdapter, matches: () => false };
-        const original = adapters.slice();
-        adapters.length = 0;
-        adapters.push(fakeAdapter);
-        try {
-            const adapter = selectAdapter(new URL("https://example.com/anything"));
-            expect(adapter).toBeNull();
-        } finally {
-            adapters.length = 0;
-            adapters.push(...original);
-        }
+        const adapter = selectAdapter(new URL("https://example.com/anything"), [fakeAdapter]);
+        expect(adapter).toBeNull();
     });
 });
 


### PR DESCRIPTION
## Problem
The content script was hard-wired to a single host (HiAnime). Its DOM
selectors, anime-id extraction, watch-page detection, drag-and-drop
behavior, and Clear-Hidden button placement all assumed `.flw-item`
markup, leaving no path to support additional anime sites without
duplicating the whole script.

## Solution
Introduce a `SiteAdapter` abstraction so each supported host contributes
its own selectors, ID extraction, and watch-page rules; the script's
core logic becomes site-agnostic. HiAnime is preserved as the catch-all
adapter (zero behavior change) and animetsu.live is added as a new
adapter covering its three URL shapes:

- `/browse` and other list pages — Plan / Hide / Watching controls
  overlay each anime card
- `/anime/{id}` — floating "Anime Info" button on the detail page
- `/watch/{id}?ep=N` — same button on the episode video page, with the
  episode prefix stripped from the document title so the show is
  tracked rather than the episode

To make tile-level features work across hosts, every managed tile is
tagged with a shared `.anime-list-tile` class. Adapters can target a
wrapper element (e.g. Animetsu's grid-slot div) via `getTileElement`
so hide and reorder act on the slot rather than the inner card,
matching how Animetsu's grid actually composes.

## Test plan
- [x] `npm run format && npm run lint && npm run test:unit` (775 / 775)
- [x] `npm run build:ext` clean
- [ ] Load `dist/` in chrome://extensions and exercise on hianime: lists,
      hide, clear-hidden, reorder
- [ ] Same on animetsu.live: `/browse` controls, hide collapses the
      slot, clear-hidden, reorder
- [ ] Animetsu `/anime/{id}` and `/watch/{id}?ep=N` show the Anime Info
      button; reorder toolbar does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)